### PR TITLE
fix GiftCardCalculator::addGiftCardPaymentsToQuote() - updating GiftCardPaymentTransfer::availableAmount

### DIFF
--- a/src/Spryker/Zed/GiftCard/Business/Calculation/GiftCardCalculator.php
+++ b/src/Spryker/Zed/GiftCard/Business/Calculation/GiftCardCalculator.php
@@ -170,7 +170,7 @@ class GiftCardCalculator implements GiftCardCalculatorInterface
             $giftCardTransfer = $this->giftCardActualValueHydrator->hydrate($giftCardTransfer);
 
             if ($giftCardPaymentTransfer) {
-                $giftCardPaymentTransfer->setAmount(
+                $giftCardPaymentTransfer->setAvailableAmount(
                     $giftCardTransfer->getActualValue(),
                 );
 


### PR DESCRIPTION
## Bug: Recalculating quote does not update giftcard value

## PR Description
recalculating quote sets giftcard value into `GiftCardPaymentTransfer::amount` instead of `GiftCardPaymentTransfer::availableAmount`.
(Maybe caused by insufficient refactoring here https://github.com/spryker/gift-card/commit/78cd8173185ccb89b2e3f384dae5be2fc38d05c4 ?)

## steps to reproduce
- have a valid giftcard
- add giftcard into cart/quote in one session (session A)
- add giftcard into cart/quote into another session (session B)
- proceed order with session A - redeem the giftcard
- reload session B
-> giftcard value still contains initial giftcard value - expected giftcard value to be updated
-> customer with session B may not be able to order due to already redeemed giftcard (expected and wanted behavior)

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
